### PR TITLE
Removed binmode => ':utf8' as it causes issues with double encoding.

### DIFF
--- a/bin/aphra
+++ b/bin/aphra
@@ -49,7 +49,7 @@ The main directory that contains the input files. Any file that is found in
 this directory will be processed and an equivalent output file will be
 created in the B<target> directory. The default value for this option is "in".
 
-    $ aphra --in some/other/directory
+    $ aphra --source some/other/directory
 
 =item B<fragments>
 

--- a/lib/App/Aphra/File.pm
+++ b/lib/App/Aphra/File.pm
@@ -143,7 +143,7 @@ sub process {
     $self->app->template->process($template, {
       page => $front_matter_hashref,
       file => $self,
-    }, $out, binmode => ':utf8')
+    }, $out)
       or croak $self->app->template->error;
 
     $orig_layout and $self->app->template->{SERVICE}{WRAPPER} = $orig_layout;


### PR DESCRIPTION
Changing any other values related to utf8 does not seem to make a difference.

The only other fix is changing the extension from "markdown" to "commonmark" in Aphra.pm, but that doesn't change the fact that the default settings will break markdown encoding. At least this way the encoding isn't busted when it's being fed to the Pandoc Provider.